### PR TITLE
Implement range blacklist support

### DIFF
--- a/modbus.yml
+++ b/modbus.yml
@@ -4,6 +4,9 @@ modules:
   - name: "fake"
     useRanges: true
     rangeSensitivity: 10
+    rangeBlocklist:
+      - start: 300003
+        end: 300004
     protocol: 'tcp/ip'
     # Certain modbus devices need special timing workarounds
     timeout: # int
@@ -44,6 +47,8 @@ modules:
         # Factor is multiplied with the scraped value to produce the metric value
         # Optional.
         factor: 3.1415926535
+        # Set to true to exclude this register from automatically generated ranges.
+        rangeBlacklist: false
 
       - name: "some_gauge"
         help: "some help for some gauge"

--- a/modbus/modbus.go
+++ b/modbus/modbus.go
@@ -250,12 +250,12 @@ func scrapeMetrics(definitions []config.MetricDef, c modbus.Client, m config.Mod
 		if err != nil {
 			return nil, err
 		}
-		for _, r := range rangeMap {
-			m, err := scrapeMetricRange(r)
+		for _, functionRange := range rangeMap {
+			rangeMetrics, err := scrapeMetricRange(functionRange)
 			if err != nil {
 				return nil, err
 			}
-			metrics = append(metrics, m...)
+			metrics = append(metrics, rangeMetrics...)
 		}
 	}
 

--- a/modbus/modbus.go
+++ b/modbus/modbus.go
@@ -23,7 +23,6 @@ import (
 
 	"github.com/RichiH/modbus_exporter/config"
 	"github.com/goburrow/modbus"
-	"sort"
 )
 
 const (
@@ -42,7 +41,7 @@ func getUseRange(m config.Module, c config.Config) bool {
 	return r
 }
 
-func getRangeSensibility(m config.Module, c config.Config) uint64 {
+func getRangeSensitivity(m config.Module, c config.Config) uint64 {
 	s := rangeDefaultSensitivity
 	if c.RangeSensitivity != 0 {
 		s = c.RangeSensitivity
@@ -193,84 +192,6 @@ func keys(m map[string]string) []string {
 	return keys
 }
 
-func generateRangeMap(definitions []config.MetricDef, c modbus.Client, sensitivity uint64) (rangeMap RangeMap, err error) {
-	//init rangeMap
-	rangeMap = initializeRangeMap(c)
-
-	//sort slice based on modAddress
-	sort.Slice(definitions, func(i, j int) bool {
-		iAddress, _ := definitions[i].Address.GetModAddress()
-		jAddress, _ := definitions[j].Address.GetModAddress()
-		return iAddress < jAddress
-	})
-
-	for _, definition := range definitions {
-		modFunction, err := definition.Address.GetModFunction()
-		if err != nil {
-			return rangeMap, fmt.Errorf("can't generate range map: %v", err)
-		}
-		r, err := validateModFunction(rangeMap, modFunction)
-		if err != nil {
-			return rangeMap, fmt.Errorf("can't generate range map: %v", err)
-		}
-		//if range definitions contain no interval add an empty interval
-		if len(r.definitions) == 0 {
-			r.definitions = append(r.definitions, []config.MetricDef{})
-		}
-		lastDefInterval := r.definitions[len(r.definitions)-1]
-		//if last interval have no content add definition to it and skip
-		if len(lastDefInterval) == 0 {
-			lastDefInterval = append(lastDefInterval, definition)
-			r.definitions[len(r.definitions)-1] = lastDefInterval
-			rangeMap[modFunction] = r
-			continue
-		}
-		firstDef := lastDefInterval[0]
-		lastDef := lastDefInterval[len(lastDefInterval)-1]
-		firstDefAddress, err := firstDef.Address.GetModAddress()
-		if err != nil {
-			return rangeMap, fmt.Errorf("can't generate range map: %v", err)
-		}
-		lastDefAddress, err := lastDef.Address.GetModAddress()
-		if err != nil {
-			return rangeMap, fmt.Errorf("can't generate range map: %v", err)
-		}
-		modAddress, err := definition.Address.GetModAddress()
-		if err != nil {
-			return rangeMap, fmt.Errorf("can't generate range map: %v", err)
-		}
-		//calculate current total offset for the current open interval
-		//if offset is more than 2000 can't be handled only in 1 request so a new interval is opened
-		totalRangeOffset := uint16(modAddress-firstDefAddress) + definition.DataType.Offset()
-		if modAddress-lastDefAddress > sensitivity || totalRangeOffset > 2000 {
-			r.definitions = append(r.definitions, []config.MetricDef{})
-		}
-		//add definition to last open interval
-		r.definitions[len(r.definitions)-1] = append(r.definitions[len(r.definitions)-1], definition)
-		rangeMap[modFunction] = r
-	}
-	return rangeMap, nil
-}
-
-// Initializes the RangeMap with predefined Modbus functions
-func initializeRangeMap(c modbus.Client) RangeMap {
-	return RangeMap{
-		1: {F: c.ReadCoils},
-		2: {F: c.ReadDiscreteInputs},
-		3: {F: c.ReadHoldingRegisters},
-		4: {F: c.ReadInputRegisters},
-	}
-}
-
-// Validates if the modFunction exists in the rangeMap and returns the Range object
-func validateModFunction(rangeMap RangeMap, modFunction uint64) (Range, error) {
-	rangeObj, ok := rangeMap[modFunction]
-	if !ok {
-		return Range{}, fmt.Errorf("invalid modFunction: %v", modFunction)
-	}
-	return rangeObj, nil
-}
-
 func scrapeMetrics(definitions []config.MetricDef, c modbus.Client, m config.Module, conf config.Config) ([]metric, error) {
 	metrics := []metric{}
 
@@ -325,7 +246,7 @@ func scrapeMetrics(definitions []config.MetricDef, c modbus.Client, m config.Mod
 			metrics = append(metrics, m)
 		}
 	} else {
-		rangeMap, err := generateRangeMap(definitions, c, getRangeSensibility(m, conf))
+		rangeMap, err := generateRangeMap(definitions, c, getRangeSensitivity(m, conf), m.RangeBlocklist)
 		if err != nil {
 			return nil, err
 		}
@@ -366,52 +287,6 @@ func scrapeMetric(definition config.MetricDef, f modbusFunc, modAddress uint64) 
 	}
 
 	return metric{definition.Name, definition.Help, definition.Labels, v, definition.MetricType}, nil
-}
-
-// scrapeMetricRange retrieves and parses Modbus register data for a given range and returns metrics or an error.
-// It computes offsets, fetches register bytes using a Modbus function, and converts data using metric definitions.
-// It auto handle "dirty" registry and parse only interested data.
-func scrapeMetricRange(r Range) ([]metric, error) {
-	var metrics []metric
-
-	for _, definitions := range r.definitions {
-		first := definitions[0]
-		last := definitions[len(definitions)-1]
-		firstAddress, err := first.Address.GetModAddress()
-		if err != nil {
-			return nil, fmt.Errorf("can't calculate mod address for %s: %v", first.Name, err)
-		}
-		lastAddress, err := last.Address.GetModAddress()
-		if err != nil {
-			return nil, fmt.Errorf("can't calculate mod address for %s: %v", last.Name, err)
-		}
-		lastOffset := last.DataType.Offset()
-		totalOffset := uint16(lastAddress-firstAddress) + lastOffset
-
-		//get all bytes from the first registry to the last
-		modBytes, err := r.F(uint16(firstAddress), totalOffset)
-		if err != nil {
-			return nil, fmt.Errorf("can't read modbus registers for %s: %v", first.Name, err)
-		}
-
-		//for each definition extract interested bytes and parse to a metric
-		for _, definition := range definitions {
-			modAddress, err := definition.Address.GetModAddress()
-			if err != nil {
-				return nil, fmt.Errorf("can't calculate mod address for %s: %v", definition.Name, err)
-			}
-			start := (modAddress - firstAddress) * 2
-			end := uint16(start) + (definition.DataType.Offset() * 2)
-			defBytes := modBytes[start:end]
-			v, err := parseModbusData(definition, defBytes)
-			if err != nil {
-				return nil, fmt.Errorf("can't parse modbus data for %s: %v", definition.Name, err)
-			}
-			metrics = append(metrics, metric{definition.Name, definition.Help, definition.Labels, v, definition.MetricType})
-		}
-	}
-
-	return metrics, nil
 }
 
 // InsufficientRegistersError is returned in Parse() whenever not enough

--- a/modbus/range.go
+++ b/modbus/range.go
@@ -1,6 +1,12 @@
 package modbus
 
-import "github.com/RichiH/modbus_exporter/config"
+import (
+	"fmt"
+	"sort"
+
+	"github.com/RichiH/modbus_exporter/config"
+	"github.com/goburrow/modbus"
+)
 
 // Range defines a Modbus range that includes a Modbus function and associated metric definitions.
 // metric definitions is a slice of continuous or semi-continuous(based on sensitivity) definition interval.
@@ -11,3 +17,144 @@ type Range struct {
 
 // RangeMap represents a mapping of Modbus function codes to corresponding Range objects.
 type RangeMap map[uint64]Range
+
+func generateRangeMap(definitions []config.MetricDef, c modbus.Client, sensitivity uint64, blocklist []config.RegisterRange) (rangeMap RangeMap, err error) {
+	rangeMap = initializeRangeMap(c)
+
+	sort.Slice(definitions, func(i, j int) bool {
+		iAddress, _ := definitions[i].Address.GetModAddress()
+		jAddress, _ := definitions[j].Address.GetModAddress()
+		return iAddress < jAddress
+	})
+
+	for _, definition := range definitions {
+		if definition.RangeBlacklist {
+			continue
+		}
+		modFunction, err := definition.Address.GetModFunction()
+		if err != nil {
+			return rangeMap, fmt.Errorf("can't generate range map: %v", err)
+		}
+		r, err := validateModFunction(rangeMap, modFunction)
+		if err != nil {
+			return rangeMap, fmt.Errorf("can't generate range map: %v", err)
+		}
+		if len(r.definitions) == 0 {
+			r.definitions = append(r.definitions, []config.MetricDef{})
+		}
+		lastDefInterval := r.definitions[len(r.definitions)-1]
+		if len(lastDefInterval) == 0 {
+			lastDefInterval = append(lastDefInterval, definition)
+			r.definitions[len(r.definitions)-1] = lastDefInterval
+			rangeMap[modFunction] = r
+			continue
+		}
+		firstDef := lastDefInterval[0]
+		lastDef := lastDefInterval[len(lastDefInterval)-1]
+		firstDefAddress, err := firstDef.Address.GetModAddress()
+		if err != nil {
+			return rangeMap, fmt.Errorf("can't generate range map: %v", err)
+		}
+		lastDefAddress, err := lastDef.Address.GetModAddress()
+		if err != nil {
+			return rangeMap, fmt.Errorf("can't generate range map: %v", err)
+		}
+		modAddress, err := definition.Address.GetModAddress()
+		if err != nil {
+			return rangeMap, fmt.Errorf("can't generate range map: %v", err)
+		}
+		totalRangeOffset := uint16(modAddress-firstDefAddress) + definition.DataType.Offset()
+		if modAddress-lastDefAddress > sensitivity || totalRangeOffset > 2000 || rangeCrossesBlock(lastDefAddress, modAddress, modFunction, blocklist) {
+			r.definitions = append(r.definitions, []config.MetricDef{})
+		}
+		r.definitions[len(r.definitions)-1] = append(r.definitions[len(r.definitions)-1], definition)
+		rangeMap[modFunction] = r
+	}
+	return rangeMap, nil
+}
+
+func initializeRangeMap(c modbus.Client) RangeMap {
+	return RangeMap{
+		1: {F: c.ReadCoils},
+		2: {F: c.ReadDiscreteInputs},
+		3: {F: c.ReadHoldingRegisters},
+		4: {F: c.ReadInputRegisters},
+	}
+}
+
+func validateModFunction(rangeMap RangeMap, modFunction uint64) (Range, error) {
+	rangeObj, ok := rangeMap[modFunction]
+	if !ok {
+		return Range{}, fmt.Errorf("invalid modFunction: %v", modFunction)
+	}
+	return rangeObj, nil
+}
+
+func rangeCrossesBlock(start, end, modFunction uint64, blocks []config.RegisterRange) bool {
+	if start > end {
+		start, end = end, start
+	}
+	for _, b := range blocks {
+		startF, err := b.Start.GetModFunction()
+		if err != nil {
+			continue
+		}
+		endF, err := b.End.GetModFunction()
+		if err != nil {
+			continue
+		}
+		if startF != endF || startF != modFunction {
+			continue
+		}
+		sAddr, _ := b.Start.GetModAddress()
+		eAddr, _ := b.End.GetModAddress()
+		if sAddr > eAddr {
+			sAddr, eAddr = eAddr, sAddr
+		}
+		if start <= eAddr && end >= sAddr {
+			return true
+		}
+	}
+	return false
+}
+
+func scrapeMetricRange(r Range) ([]metric, error) {
+	var metrics []metric
+
+	for _, definitions := range r.definitions {
+		first := definitions[0]
+		last := definitions[len(definitions)-1]
+		firstAddress, err := first.Address.GetModAddress()
+		if err != nil {
+			return nil, fmt.Errorf("can't calculate mod address for %s: %v", first.Name, err)
+		}
+		lastAddress, err := last.Address.GetModAddress()
+		if err != nil {
+			return nil, fmt.Errorf("can't calculate mod address for %s: %v", last.Name, err)
+		}
+		lastOffset := last.DataType.Offset()
+		totalOffset := uint16(lastAddress-firstAddress) + lastOffset
+
+		modBytes, err := r.F(uint16(firstAddress), totalOffset)
+		if err != nil {
+			return nil, fmt.Errorf("can't read modbus registers for %s: %v", first.Name, err)
+		}
+
+		for _, definition := range definitions {
+			modAddress, err := definition.Address.GetModAddress()
+			if err != nil {
+				return nil, fmt.Errorf("can't calculate mod address for %s: %v", definition.Name, err)
+			}
+			start := (modAddress - firstAddress) * 2
+			end := uint16(start) + (definition.DataType.Offset() * 2)
+			defBytes := modBytes[start:end]
+			v, err := parseModbusData(definition, defBytes)
+			if err != nil {
+				return nil, fmt.Errorf("can't parse modbus data for %s: %v", definition.Name, err)
+			}
+			metrics = append(metrics, metric{definition.Name, definition.Help, definition.Labels, v, definition.MetricType})
+		}
+	}
+
+	return metrics, nil
+}


### PR DESCRIPTION
## Summary
- add module-level rangeBlocklist with RegisterRange type
- skip over blocked ranges when assembling metric ranges
- validate rangeBlocklist entries on load
- document example rangeBlocklist usage

## Testing
- `go build ./...` *(passes)*
- `go test ./...` *(passes)*

------
https://chatgpt.com/codex/tasks/task_e_6877b926cea48321ba0edf7eeb12a1b7